### PR TITLE
Add a lazy version of language_code_formfield_callback

### DIFF
--- a/translated_fields/utils.py
+++ b/translated_fields/utils.py
@@ -1,3 +1,5 @@
+from django.forms import Field
+from django.utils.functional import lazy
 from django.utils.text import capfirst
 
 from .fields import TranslatedField, to_attribute
@@ -8,6 +10,7 @@ __all__ = [
     "fallback_to_default",
     "fallback_to_any",
     "language_code_formfield_callback",
+    "language_code_formfield_callback_lazy",
 ]
 
 
@@ -48,3 +51,5 @@ def language_code_formfield_callback(db_field, **kwargs):
     if language_code:
         kwargs["label"] = "%s [%s]" % (capfirst(db_field.verbose_name), language_code)
     return db_field.formfield(**kwargs)
+
+language_code_formfield_callback_lazy = lazy(language_code_formfield_callback, Field)


### PR DESCRIPTION
Currently, if we want to use `language_code_formfield_callback` in a ModelForm, the label is not translated before adding the language code, by adding a lazy version, the label can be translated on the fly according to the user's language setting.